### PR TITLE
Fix channel_gamma compatibility func

### DIFF
--- a/library/sn3218/__init__.py
+++ b/library/sn3218/__init__.py
@@ -142,7 +142,7 @@ def output_raw(values):
 
 
 def channel_gamma(channel, gamma_table):
-    _get_sn3218().enable()
+    _get_sn3218().channel_gamma(channel, gamma_table)
 
 
 def enable_leds(enable_mask):


### PR DESCRIPTION
Came across some breakage when attempting to use the dothat module with the sn3218 v2 module: specifically that the `default_gamma_table` attribute isn't available at the module level which breaks `dothat.backlight` (and I assume `dot3k.backlight` from the looks of it). When digging into the background I also found this error in the compatibility funcs.

Note this PR *doesn't* fix the issue with the display-o-tron but I don't think it's actually fixable from this end (I tried using module level data-descriptors to work around it without pre-constructing an instance of `SN3218` but that doesn't work as the module isn't a class). I'll post a separate PR to make display-o-tron compatible with both v2 and v1 versions of this module.